### PR TITLE
server: use blake3 as the paste name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,6 +27,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayref"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4c527152e37cf757a3f78aae5a06fbeefdb07ccc535c980a3208ee3060dd544"
+
+[[package]]
+name = "arrayvec"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8da52d66c7071e2e3fa2a1e5c6d088fec47b593032b254f5e980de8ea54454d6"
+
+[[package]]
 name = "async-stream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -100,13 +112,13 @@ checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
 name = "bin"
 version = "2.2.1"
 dependencies = [
+ "blake3",
  "clap",
  "once_cell",
  "rand",
  "rocket",
  "rocket_dyn_templates",
  "rust-embed",
- "sha256",
  "syntect",
  "time 0.3.7",
  "tree_magic",
@@ -134,6 +146,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "blake3"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a08e53fc5a564bb15bfe6fae56bd71522205f1f91893f9c0116edad6496c183f"
+dependencies = [
+ "arrayref",
+ "arrayvec",
+ "cc",
+ "cfg-if 1.0.0",
+ "constant_time_eq",
+ "digest 0.10.3",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,6 +176,15 @@ name = "block-buffer"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
+dependencies = [
+ "generic-array 0.14.5",
+]
+
+[[package]]
+name = "block-buffer"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf7fe51849ea569fd452f37822f606a5cabb684dc918707a0193fd4664ff324"
 dependencies = [
  "generic-array 0.14.5",
 ]
@@ -294,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fbdcdcb6d86f71c5e97409ad45898af11cbc995b4ee8112d59095a28d376c935"
 
 [[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
+
+[[package]]
 name = "cookie"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -330,6 +371,16 @@ checksum = "cfcae03edb34f947e64acdb1c33ec169824e20657e9ecb61cef6c8c74dcb8120"
 dependencies = [
  "cfg-if 1.0.0",
  "lazy_static",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array 0.14.5",
+ "typenum",
 ]
 
 [[package]]
@@ -387,6 +438,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
 dependencies = [
  "generic-array 0.14.5",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2fb860ca6fafa5552fb6d0e816a69c8e49f0908bf524e30a90d97c85892d506"
+dependencies = [
+ "block-buffer 0.10.2",
+ "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -711,12 +773,6 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "hex"
-version = "0.4.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1880,16 +1936,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha256"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e84a7f596c081d359de5e06a83877138bc3c4483591e1af1916e1472e6e146e"
-dependencies = [
- "hex",
- "sha2",
-]
-
-[[package]]
 name = "sharded-slab"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2031,6 +2077,12 @@ name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
+name = "subtle"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ syntect = "4.6.0"
 rust-embed="6.3.0"
 clap = { version = "3.0.9", features = ["derive", "env"] }
 once_cell = "1"
-sha256 = "1"
+blake3 = "1.3.1"
 time = { version = "0.3", features = ["formatting"] }
 
 [dependencies.rocket_dyn_templates]

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,7 +24,7 @@ const SERVER_VERSION: &str = concat!(
     ") (Rocket)"
 );
 static BINARY_ETAG: Lazy<String> =
-    Lazy::new(|| sha256::digest(BINARY_VERSION));
+    Lazy::new(|| blake3::hash(BINARY_VERSION.as_bytes()).to_string());
 
 #[derive(RustEmbed)]
 #[folder = "templates/"]

--- a/src/models/paste_id.rs
+++ b/src/models/paste_id.rs
@@ -12,12 +12,9 @@ fn valid_id(id: &str) -> bool {
 }
 
 impl<'a> PasteId<'a> {
-    pub fn new(size: usize) -> PasteId<'static> {
-        let id: String = rand::thread_rng()
-            .sample_iter(&Alphanumeric)
-            .take(size)
-            .map(char::from)
-            .collect();
+    pub fn new(size: usize, input: &[u8]) -> PasteId<'static> {
+        let mut id: String = blake3::hash(input).to_string();
+        id.truncate(size);
 
         PasteId(Cow::Owned(id))
     }

--- a/src/models/paste_id.rs
+++ b/src/models/paste_id.rs
@@ -3,8 +3,6 @@ use std::fmt;
 
 use rocket::request::FromParam;
 
-use rand::{self, distributions::Alphanumeric, Rng};
-
 pub struct PasteId<'a>(Cow<'a, str>);
 
 fn valid_id(id: &str) -> bool {

--- a/src/routes/submit.rs
+++ b/src/routes/submit.rs
@@ -13,13 +13,18 @@ pub struct PasteIdForm {
 
 #[post("/submit", data = "<paste>")]
 pub async fn submit(paste: Form<PasteIdForm>) -> Redirect {
-    let id = PasteId::new(6);
+    let content = &paste.content;
+    let id = PasteId::new(7, content.as_bytes());
 
     let filepath = Path::new(&get_upload_dir()).join(format!("{id}", id = id));
-    let content = &paste.content;
     let ext = &paste.ext;
+    let url = format!("/p/{id}.{ext}", id = id, ext = ext);
+
+    if filepath.is_file() {
+        return Redirect::to(url);
+    }
 
     fs::write(&filepath, content).expect("Unable to write to the file");
 
-    Redirect::to(format!("/p/{id}.{ext}", id = id, ext = ext))
+    Redirect::to(url)
 }

--- a/src/routes/upload.rs
+++ b/src/routes/upload.rs
@@ -5,25 +5,31 @@ use std::path::Path;
 use crate::get_parsed_args;
 use crate::models::paste_id::PasteId;
 
-// Currently I know only these, if you need another file type feel free to add them 
+// Currently I know only these, if you need another file type feel free to add them
 // and possibly make a PR
-const SUPPORTED_MIMETYPES: [&'static str; 4] = [
-    "application/json", "application/xml", "application/mbox", "application/x-shellscript"
+const SUPPORTED_MIMETYPES: [&str; 4] = [
+    "application/json",
+    "application/xml",
+    "application/mbox",
+    "application/x-shellscript",
 ];
 
 // text/x-tex: Rust detect PDF file as this one.
-const BLACKLIST: [&'static str; 1] = [
-    "text/x-tex"
-];
+const BLACKLIST: [&str; 1] = ["text/x-tex"];
 
 #[post("/", data = "<paste>")]
 pub async fn upload(mut paste: Data<'_>) -> Result<String, &str> {
     let args = get_parsed_args();
-    let file = paste.peek(args.binary_upload_limit.mebibytes().as_u64() as usize).await;
+    let file = paste
+        .peek(args.binary_upload_limit.mebibytes().as_u64() as usize)
+        .await;
     let mime = tree_magic::from_u8(file);
     println!("{}", mime);
 
-    if BLACKLIST.contains(&mime.as_str()) || (!mime.contains("text") && !SUPPORTED_MIMETYPES.contains(&mime.as_str())) { 
+    if BLACKLIST.contains(&mime.as_str())
+        || (!mime.contains("text")
+            && !SUPPORTED_MIMETYPES.contains(&mime.as_str()))
+    {
         return Err("UNSUPPORTED_MIMETYPE");
     }
 


### PR DESCRIPTION
We can prevent having 2 same pastes by using this instead of a random name, and right now i take the first 7 letters in the hash as the paste name, it seems reasonable for me.

---

Thanks for taking the time !

Please ensure that some basic checks are passed before creating this Pull Request:

- [x] Cargo Format
    - Run `cargo fmt` on the project.
    
- [x] Clippy lints
    - Run `cargo clippy -- -Dwarnings` on the project to check for suggestions
    - Run `cargo clippy --fix` to let clippy apply the suggestions itself, if any.

This can be tiresome for frequent contributors, so it might would be better if
you used a git pre-push hook as mentioned in the [readme](readme.md#hacking).

The [Build CI](.github/workflow/buildci.yaml) will also check whether the project can be compiled and
cross-compiled to arm64 without any errors.
